### PR TITLE
Add feature: autoselect translator

### DIFF
--- a/docs/translators.md
+++ b/docs/translators.md
@@ -28,7 +28,7 @@ Usage outside of nixpkgs:
 Usage inside nixpkgs:
 - generic lock file must be pre-generated using dream2nix cli
 
-## external (running outside of nix build)
+## impure (running outside of nix build)
 Suitable if:
 - the input is missing URLs or hashes
 - the method used to process the input contains impurities, like for example:

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,8 @@
       {
         overlay = curr: prev: {};
 
+        lib.dream2nix = dream2nixFor;
+
         defaultApp = forAllSystems (system: self.apps."${system}".cli);
 
         apps = forAllSystems (system: {
@@ -43,6 +45,12 @@
             "type" = "app";
             "program" = builtins.toString (dream2nixFor."${system}".apps.install);
           };
+        });
+
+        devShell = forAllSystems (system: nixpkgsFor."${system}".mkShell {
+          shellHook = ''
+            export NIX_PATH=nixpkgs=${nixpkgs}
+          '';
         });
       };
 }

--- a/specifications/generic-lock-example.json
+++ b/specifications/generic-lock-example.json
@@ -16,6 +16,7 @@
     "buildSystem": "python",
     "buildSystemFormatVersion": 1,
     "producedBy": "translator-poetry-1",
+    "rootPackage": "requests",
     "dependencyGraph": {
       "requests": [
         "certifi"

--- a/specifications/translator-call-example.json
+++ b/specifications/translator-call-example.json
@@ -1,5 +1,5 @@
 {
-  "inputFiles": [
+  "inputPaths": [
     "./some_project_src/requirements.txt",
     "./some_project_src/requirements-dev.txt"
   ]

--- a/src/apps/default.nix
+++ b/src/apps/default.nix
@@ -4,6 +4,7 @@
   externalSources,
   location,
   translators,
+  ...
 }:
 let
   callPackage = pkgs.callPackage;

--- a/src/default.nix
+++ b/src/default.nix
@@ -8,10 +8,16 @@
 }:
 
 let
-  callPackage = pkgs.callPackage;
+
+  utils = callPackage ./utils.nix {};
+
+  callPackage = f: args: pkgs.callPackage f (args // {
+    inherit callPackage;
+    inherit utils;
+  });
 
   externals = {
-    npmlock2nix = callPackage "${externalSources}/npmlock2nix/internal.nix" {};
+    npmlock2nix = pkgs.callPackage "${externalSources}/npmlock2nix/internal.nix" {};
   };
 in
 

--- a/src/translators/default.nix
+++ b/src/translators/default.nix
@@ -1,19 +1,33 @@
 {
+  lib,
+  callPackage,
   pkgs,
 
   externalSources,
   externals,
   location,
+  utils,
 }: 
 let
 
   lib = pkgs.lib;
+  callTranslator = subsystem: type: name: file: args: 
+    let
+      translator = callPackage file (args // {
+        inherit externals;
+        translatorName = name;
+      });
+    in
+      # if the translator is a pure nix translator,
+      # generate a translatorBin for CLI compatibility
+      if translator ? translateBin then translator
+      else translator // {
+        translateBin = wrapPureTranslator [ subsystem type name ];
+      };
 
-  callPackage = pkgs.callPackage;
-  callTranslator = file: name: args: pkgs.callPackage file (args // {
-    inherit externals;
-    translatorName = name;
-  });
+  buildSystems = dirNames ./.;
+
+  translatorTypes = [ "impure" "ifd" "pure" ];
 
   # every translator must provide 'bin/translate'
   translatorExec = translatorPkg: "${translatorPkg}/bin/translate";
@@ -22,48 +36,45 @@ let
   dirNames = dir: lib.attrNames (lib.filterAttrs (name: type: type == "directory") (builtins.readDir dir));
 
   # wrapPureTranslator
-  wrapPureTranslator = translatorAttrPath: pkgs.writeScriptBin "translate" ''
-    #!${pkgs.bash}/bin/bash
+  wrapPureTranslator = translatorAttrPath:
+    let
+      bin = pkgs.writeScriptBin "translate" ''
+        #!${pkgs.bash}/bin/bash
 
-    echo wrapPureTranslator
+        jsonInputFile=$1
+        outputFile=$(${pkgs.jq}/bin/jq '.outputFile' -c -r $jsonInputFile)
+        export d2nExternalSources=${externalSources}
 
-    jsonInputFile=$1
-    outputFile=$(${pkgs.jq}/bin/jq '.outputFile' -c -r $jsonInputFile)
-    export d2nExternalSources=${externalSources}
+        nix eval --impure --raw --expr "
+          builtins.toJSON (
+            (import ${location} {}).translators.translators.${
+              lib.concatStringsSep "." translatorAttrPath
+            }.translate 
+              (builtins.fromJSON (builtins.readFile '''$1'''))
+          )
+        " | ${pkgs.jq}/bin/jq > $outputFile
+      '';
+    in
+      bin.overrideAttrs (old: {
+        name = "translator-${lib.concatStringsSep "-" translatorAttrPath}";
+      });
 
-    nix eval --impure --raw --expr "
-      builtins.toJSON (
-        (import ${location} {}).translators.translatorsInternal.${
-          lib.concatStringsSep "." translatorAttrPath
-        }.translate 
-          (builtins.fromJSON (builtins.readFile '''$1'''))
-      )
-    " | ${pkgs.jq}/bin/jq > $outputFile
-  '';
-
+  # attrset of: subsystem -> translator-type -> (function subsystem translator-type)
   mkTranslatorsSet = function:
     lib.genAttrs (dirNames ./.) (subsystem:
       lib.genAttrs
-        (lib.filter (dir: builtins.pathExists (./. + "/${subsystem}/${dir}")) [ "impure" "ifd" "pure" ])
+        (lib.filter (dir: builtins.pathExists (./. + "/${subsystem}/${dir}")) translatorTypes)
         (transType: function subsystem transType)
     );
 
-  
+  # attrset of: subsystem -> translator-type -> translator
   translators = mkTranslatorsSet (subsystem: type:
     lib.genAttrs (dirNames (./. + "/${subsystem}/${type}")) (translatorName:
-      if type == "impure" then
-        callTranslator (./. + "/${subsystem}/${type}/${translatorName}") translatorName {}
-      else
-        wrapPureTranslator [ subsystem type translatorName ]
+      callTranslator subsystem type translatorName (./. + "/${subsystem}/${type}/${translatorName}") {}
     )
   );
 
-  translatorsInternal = mkTranslatorsSet (subsystem: type:
-    lib.genAttrs (dirNames (./. + "/${subsystem}/${type}")) (translatorName:
-      callTranslator (./. + "/${subsystem}/${type}/${translatorName}") translatorName {}
-    )
-  );
-
+  # json file exposing all existing translators to CLI
   translatorsJsonFile =
     pkgs.writeText
       "translators.json"
@@ -73,7 +84,67 @@ let
         )
       ));
 
+  # filter translators by compatibility for the given input paths
+  compatibleTranslators = paths: translators_:
+    let
+      compatible = 
+        lib.mapAttrs (subsystem: types:
+          lib.mapAttrs (type: translators:
+            lib.filterAttrs (name: translator:
+              translator ? compatiblePaths && translator.compatiblePaths paths == paths
+            ) translators
+          ) types
+        ) translators_;
+    in
+      # purge empty attrsets
+      lib.filterAttrsRecursive (k: v: v != {}) (lib.filterAttrsRecursive (k: v: v != {}) compatible);
+
+  # reduce translators by a given selector
+  # selector examples:  
+  #  - "python"
+  #  - "python.impure"
+  #  - "python.impure.pip"
+  reduceTranslatorsBySelector = selector: translators_:
+    let
+      split = lib.splitString "." (lib.removeSuffix "." selector);
+      selectedSubsystems = if split != [ "" ] then [ (lib.elemAt split 0) ] else buildSystems;
+      selectedTypes = if lib.length split > 1 then [ (lib.elemAt split 1) ] else translatorTypes;
+      selectedName = if lib.length split > 2 then lib.elemAt split 2 else null;
+      compatible = builtins.trace "split: ${builtins.toString (builtins.length split)} subs: ${builtins.toString selectedSubsystems} types: ${builtins.toString selectedTypes} name: ${builtins.toString selectedName}"
+        lib.mapAttrs (subsystem: types:
+          lib.mapAttrs (type: translators:
+            lib.filterAttrs (name: translator:
+              lib.elem subsystem selectedSubsystems
+              && lib.elem type selectedTypes
+              && lib.elem selectedName [ name null ]
+            ) translators
+          ) types
+        ) translators_;
+    in
+      # purge empty attrsets
+      lib.filterAttrsRecursive (k: v: v != {}) (lib.filterAttrsRecursive (k: v: v != {}) compatible);
+
+
+  # return the correct translator bin for the given input paths
+  selectTranslatorBin = utils.makeCallableViaEnv (
+    {
+      selector,  # like 'python.impure' or 'python.impure.pip'
+      inputPaths,  # input paths to translate
+      ...
+    }:
+    let
+      selectedTranslators = reduceTranslatorsBySelector selector translators;
+      compatTranslators = compatibleTranslators inputPaths selectedTranslators;
+    in
+      if selectedTranslators == {} then
+        throw "The selector '${selector}' does not select any known translators"
+      else if compatTranslators == {} then
+        throw "Could not find any translator which is compatible to the given inputs: ${builtins.toString inputPaths}"
+      else
+        (lib.head (lib.attrValues (lib.head (lib.attrValues (lib.head (lib.attrValues compatTranslators)))))).translateBin
+  );
+
 in
 {
-  inherit translators translatorsInternal translatorsJsonFile;
+  inherit translators translatorsJsonFile selectTranslatorBin;
 }

--- a/src/translators/nodejs/pure/npmlock2nix/default.nix
+++ b/src/translators/nodejs/pure/npmlock2nix/default.nix
@@ -1,16 +1,18 @@
 {
   externals,
   translatorName,
+  utils,
+  ...
 }:
 
 let
   translate =
     {
-      inputFiles,
+      inputPaths,
       ...
     }:
     let
-      parsed = externals.npmlock2nix.readLockfile (builtins.elemAt inputFiles 0);
+      parsed = externals.npmlock2nix.readLockfile (builtins.elemAt inputPaths 0);
     in
     {
       sources = builtins.mapAttrs (pname: pdata:{
@@ -32,8 +34,10 @@ let
       };
     };
 
+    compatiblePaths = paths: utils.compatibleTopLevelPaths ".*(package-lock\\.json)" paths;
+
 in
 
 {
-  inherit translate;
+  inherit translate compatiblePaths;
 }

--- a/src/translators/python/impure/pip/default.nix
+++ b/src/translators/python/impure/pip/default.nix
@@ -1,43 +1,52 @@
 {
+  # dream2nix utils
+  utils,
+
   bash,
   jq,
+  lib,
   python3,
   writeScriptBin,
   ...
 }:
 
-#
-# the input format is specified in /specifications/translator-call-example.json
+{
 
-writeScriptBin "translate" ''
-  #!${bash}/bin/bash
+  # the input format is specified in /specifications/translator-call-example.json
+  translateBin = writeScriptBin "translate" ''
+    #!${bash}/bin/bash
 
-  set -Eeuo pipefail
+    set -Eeuo pipefail
 
-  # accroding to the spec, the translator reads the input from a json file
-  jsonInput=$1
+    # accroding to the spec, the translator reads the input from a json file
+    jsonInput=$1
 
-  # extract the 'inputFiles' field from the json
-  inputFiles=$(${jq}/bin/jq '.inputFiles | .[]' -c -r $jsonInput)
-  outputFile=$(${jq}/bin/jq '.outputFile' -c -r $jsonInput)
+    # extract the 'inputPaths' field from the json
+    inputPaths=$(${jq}/bin/jq '.inputPaths | .[]' -c -r $jsonInput)
+    outputFile=$(${jq}/bin/jq '.outputFile' -c -r $jsonInput)
 
-  # pip executable
-  pip=${python3.pkgs.pip}/bin/pip
+    # pip executable
+    pip=${python3.pkgs.pip}/bin/pip
 
-  # prepare temporary directory
-  tmp=translateTmp
-  rm -rf $tmp
-  mkdir $tmp
+    # prepare temporary directory
+    tmp=translateTmp
+    rm -rf $tmp
+    mkdir $tmp
 
-  # download files according to requirements
-  $pip download \
-    --no-cache \
-    --dest $tmp \
-    --progress-bar off \
-    -r ''${inputFiles/$'\n'/$' -r '}
+    # download files according to requirements
+    $pip download \
+      --no-cache \
+      --dest $tmp \
+      --progress-bar off \
+      -r ''${inputPaths/$'\n'/$' -r '}
 
-  # generate the generic lock from the downloaded list of files
-  ${python3}/bin/python ${./generate-generic-lock.py} $tmp $outputFile
+    # generate the generic lock from the downloaded list of files
+    ${python3}/bin/python ${./generate-generic-lock.py} $tmp $outputFile
 
-  rm -rf $tmp
-''
+    rm -rf $tmp
+  '';
+
+
+  # from a given list of paths, this function returns all paths which can be processed by this translator
+  compatiblePaths = paths: utils.compatibleTopLevelPaths ".*(requirements).*\\.txt" paths;
+}

--- a/src/utils.nix
+++ b/src/utils.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  ...
+}:
+rec {
+  basename = path: lib.last (lib.splitString "/" path);
+
+  dirname = path: builtins.concatStringsSep "/" (lib.init (lib.splitString "/" path));
+
+  isFile = path: (builtins.readDir (dirname path))."${basename path}" ==  "regular";
+
+  isDir = path: (builtins.readDir (dirname path))."${basename path}" ==  "directory";
+
+  listFiles = path: lib.filterAttrs (n: v: v == "regular") (builtins.listDir path);
+
+  matchTopLevelFiles = pattern: path:
+    # is dir
+    if isDir path then
+      builtins.all (f: matchTopLevelFiles pattern f) (listFiles path)
+    
+    # is file
+    else
+      let
+        match = (builtins.match pattern path);
+      in
+        if match == null then false else builtins.any (m: m != null) match;
+  
+  compatibleTopLevelPaths = pattern: paths:
+    lib.filter
+      (path:
+        matchTopLevelFiles
+          pattern
+          path
+      )
+      paths;
+
+  # allow a function to receive its input from an environment variable
+  # whenever an empty set is passed
+  makeCallableViaEnv = func: args:
+    if args == {} then
+      func (builtins.fromJSON (builtins.readFile (builtins.getEnv "FUNC_ARGS")))
+    else
+      func args;
+
+}


### PR DESCRIPTION
From now on the user does not need to select the translator anymore.
It is sufficient to just pass source trees or files and the framework will automatically figure out which translator to use.