### PR TITLE
nodejs builder/translator and CLI improvements

### DIFF
--- a/src/apps/cli/commands/add.py
+++ b/src/apps/cli/commands/add.py
@@ -451,4 +451,4 @@ class AddCommand(Command):
     print(f"Created {output}/dream-lock.json")
 
     if config['isRepo']:
-      sp.run(f"git add -N {output}")
+      sp.run(f"git add -N {output}".split())

--- a/src/apps/cli/commands/add.py
+++ b/src/apps/cli/commands/add.py
@@ -449,3 +449,6 @@ class AddCommand(Command):
         print(f"Created {output}/default.nix")
 
     print(f"Created {output}/dream-lock.json")
+
+    if config['isRepo']:
+      sp.run(f"git add -N {output}")

--- a/src/apps/cli/utils.py
+++ b/src/apps/cli/utils.py
@@ -25,10 +25,10 @@ def find_repo_root():
 
 with open(os.environ.get("dream2nixConfig")) as f:
   config = json.load(f)
-  config.["isRepo"] = False
+  config["isRepo"] = False
   if config['repoName'] and config ['packagesDir']:
     config['packagesDir'] = f"{find_repo_root()}/{config['packagesDir']}"
-    config.["isRepo"] = True
+    config["isRepo"] = True
 
 def checkLockJSON(lock):
   lock_schema_raw=open(dream2nix_src+"/specifications/dream-lock-schema.json").read()

--- a/src/apps/cli/utils.py
+++ b/src/apps/cli/utils.py
@@ -25,8 +25,10 @@ def find_repo_root():
 
 with open(os.environ.get("dream2nixConfig")) as f:
   config = json.load(f)
+  config.["isRepo"] = False
   if config['repoName'] and config ['packagesDir']:
     config['packagesDir'] = f"{find_repo_root()}/{config['packagesDir']}"
+    config.["isRepo"] = True
 
 def checkLockJSON(lock):
   lock_schema_raw=open(dream2nix_src+"/specifications/dream-lock-schema.json").read()

--- a/src/builders/nodejs/granular/default.nix
+++ b/src/builders/nodejs/granular/default.nix
@@ -48,11 +48,6 @@ let
 
   b = builtins;
 
-  # tells if a dependency introduces a cycle
-  #   -> needs to be built in a combined derivation
-  isCyclic = name: version:
-    (getCyclicDependencies name version) != [];
-
   nodejsVersion = subsystemAttrs.nodejsVersion;
 
   nodejs =
@@ -72,23 +67,8 @@ let
         lib.genAttrs
           versions
           (version:
-            if isCyclic name version
-                || b.elem name standalonePackageNames then
-              makeCombinedPackage name version
-            else
               makePackage name version))
       packageVersions;
-  
-  makeCombinedPackage = name: version:
-    let
-      built =
-        buildPackageWithOtherBuilder {
-          inherit name version;
-          builder = builders.nodejs.node2nix;
-          inject = {};
-        };
-    in
-      built.defaultPackage;
 
   # Generates a derivation for a specific package name + version
   makePackage = name: version:

--- a/src/builders/nodejs/granular/fix-package.py
+++ b/src/builders/nodejs/granular/fix-package.py
@@ -49,6 +49,12 @@ if 'dependencies' in package_json:
     if 'bundledDependencies' in package_json\
         and pname in package_json['bundledDependencies']:
       continue
+    if pname not in available_deps:
+      print(
+        f"WARNING: Dependency {pname} wanted but not available. Ignoring.",
+        file=sys.stderr
+      )
+      continue
     if available_deps[pname] != package_json['dependencies'][pname]:
       package_json['dependencies'][pname] = available_deps[pname]
       changed = True

--- a/src/builders/nodejs/granular/fix-package.py
+++ b/src/builders/nodejs/granular/fix-package.py
@@ -65,7 +65,7 @@ if 'dependencies' in package_json:
       )
 
 # create symlinks for executables (bin entries from package.json)
-if 'bin' in package_json:
+if 'bin' in package_json and package_json['bin']:
   bin = package_json['bin']
 
   if isinstance(bin, str):

--- a/src/translators/nodejs/pure/package-lock/default.nix
+++ b/src/translators/nodejs/pure/package-lock/default.nix
@@ -14,6 +14,7 @@
       inputDirectories,
       inputFiles,
 
+      name,
       noDev,
       nodejs,
       ...
@@ -73,8 +74,17 @@
       utils.simpleTranslate translatorName {
         # values
         inputData = packageLockWithPinnedVersions;
-        mainPackageName = parsed.name;
-        mainPackageVersion = parsed.version;
+
+        mainPackageName =
+          parsed.name or
+          (if name != "{automatic}" then name else
+            throw (
+              "Could not identify package name. "
+              + "Please specify extra argument 'name'"
+            ));
+
+        mainPackageVersion = parsed.version or "unknown";
+
         mainPackageDependencies =
           lib.mapAttrsToList
             (pname: pdata:
@@ -82,7 +92,9 @@
             (lib.filterAttrs
               (pname: pdata: ! (pdata.dev or false) || dev)
               parsedDependencies);
+              
         subsystemName = "nodejs";
+
         subsystemAttrs = { nodejsVersion = args.nodejs; };
 
         # functions
@@ -155,6 +167,16 @@
     };
 
   extraArgs = {
+
+    name = {
+      description = "The name of the main package";
+      examples = [
+        "react"
+        "@babel/code-frame"
+      ];
+      default = "{automatic}";
+      type = "argument";
+    };
 
     noDev = {
       description = "Exclude development dependencies";


### PR DESCRIPTION
Done:
  - builder: just skip cyclic dependencies instead of delegating to combined builder
  - builder: fix bug: crash if `bin` field in package.json is empty string
  - package-lock translator: allow `name` to be specified through CLI